### PR TITLE
Improve Huffman decode symbol parsing

### DIFF
--- a/libinflate.js
+++ b/libinflate.js
@@ -94,6 +94,14 @@ function huffmanEncode(data, codeMap) {
     return encoded;
 }
 
+function parseSymbol(symbol) {
+    if (typeof symbol === "string" && symbol.startsWith("(") && symbol.endsWith(")")) {
+        let [distance, length] = symbol.slice(1, -1).split(',').map(Number);
+        return { distance, length };
+    }
+    return { byte: Number(symbol) };
+}
+
 function deflate(data) {
     let lz77Data = lz77_compress(data);
     let frequencies = buildFrequencyTable(lz77Data);
@@ -114,7 +122,7 @@ function huffmanDecode(encodedData, huffmanTree) {
         }
 
         if (node.symbol !== undefined) {
-            decoded.push(node.symbol);
+            decoded.push(parseSymbol(node.symbol));
             node = huffmanTree;  // Reset to the root for the next symbol
         }
     }


### PR DESCRIPTION
## Summary
- add a helper `parseSymbol` to convert decoded symbol strings to the LZ77 object format
- use `parseSymbol` inside `huffmanDecode` so `lz77_decompress` receives `{byte}` or `{distance,length}` objects

## Testing
- `node -e "require('./libinflate')"`

------
https://chatgpt.com/codex/tasks/task_e_68409c424070832883e5ef96c196b6c8