### PR TITLE
Improve README usage and deflate output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,34 @@ A simple implementation of the INFLATE (and DEFLATE) algorithm in JavaScript.
 ## Installation
 
 ```bash
-npm install libINFLATE```
-
+npm install libINFLATE
+```
 
 ## Usage
-const { inflate, deflate } = require('libINFLATE');
+
+`deflate` compresses an array of bytes and returns an object containing the encoded bit string and the Huffman tree used during compression. `inflate` expects those two values in order to recreate the original data.
+
+```javascript
+const { deflate, inflate } = require('libINFLATE');
+
+const input = [/* array of byte values */];
+const { encodedData, huffmanTree } = deflate(input);
+const output = inflate(encodedData, huffmanTree);
+```
+
+### Example
+
+Below is a small example that compresses a string and then decompresses it back to verify the output.
+
+```javascript
+const { deflate, inflate } = require('./libinflate');
+
+const text = 'hello world';
+const data = Array.from(Buffer.from(text));
+
+const { encodedData, huffmanTree } = deflate(data);
+const resultBytes = inflate(encodedData, huffmanTree);
+const resultText = Buffer.from(resultBytes).toString();
+
+console.log(resultText); // -> 'hello world'
+```

--- a/libinflate.js
+++ b/libinflate.js
@@ -100,7 +100,7 @@ function deflate(data) {
     let huffmanTree = buildHuffmanTree(frequencies);
     let huffmanCodes = generateHuffmanCodes(huffmanTree);
     let encodedData = huffmanEncode(lz77Data, huffmanCodes);
-    return encodedData;
+    return { encodedData, huffmanTree };
 }
 
 function huffmanDecode(encodedData, huffmanTree) {


### PR DESCRIPTION
## Summary
- explain that `deflate` returns `{encodedData, huffmanTree}`
- include instructions showing how to call `inflate`
- add short example script demonstrating compression/decompression
- update `deflate` implementation to return the Huffman tree along with the data

## Testing
- `node -e "require('./libinflate');"`


------
https://chatgpt.com/codex/tasks/task_e_68409c436f308328bd25e10c4d7591e7