### PR TITLE
Return Huffman tree from deflate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,16 @@ npm install libINFLATE```
 
 
 ## Usage
+
+```javascript
 const { inflate, deflate } = require('libINFLATE');
+
+// Prepare an array of bytes/characters to compress
+const input = Array.from('example text');
+
+// deflate now returns the encoded data and the Huffman tree
+const { encodedData, huffmanTree } = deflate(input);
+
+// pass the tree back to `inflate` to get the original data
+const output = inflate(encodedData, huffmanTree).join('');
+```

--- a/libinflate.js
+++ b/libinflate.js
@@ -100,7 +100,7 @@ function deflate(data) {
     let huffmanTree = buildHuffmanTree(frequencies);
     let huffmanCodes = generateHuffmanCodes(huffmanTree);
     let encodedData = huffmanEncode(lz77Data, huffmanCodes);
-    return encodedData;
+    return { encodedData, huffmanTree };
 }
 
 function huffmanDecode(encodedData, huffmanTree) {
@@ -137,7 +137,18 @@ function lz77_decompress(data) {
 }
 
 function inflate(encodedData, huffmanTree) {
-    let lz77Data = huffmanDecode(encodedData, huffmanTree);
+    let symbols = huffmanDecode(encodedData, huffmanTree);
+    let lz77Data = symbols.map(sym => {
+        if (/^\(\d+,\d+\)$/.test(sym)) {
+            let [distance, length] = sym.slice(1, -1).split(',').map(Number);
+            return { distance, length };
+        }
+        let num = Number(sym);
+        if (!isNaN(num) && String(num) === sym) {
+            return { byte: num };
+        }
+        return { byte: sym };
+    });
     let originalData = lz77_decompress(lz77Data);
     return originalData;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { deflate, inflate } = require('../libinflate');
+
+const inputStr = 'hello hello hello';
+const input = Array.from(inputStr);
+const { encodedData, huffmanTree } = deflate(input);
+const outputArr = inflate(encodedData, huffmanTree);
+const outputStr = outputArr.join('');
+
+assert.strictEqual(outputStr, inputStr);
+console.log('Compression followed by decompression was successful.');


### PR DESCRIPTION
## Summary
- return both the encoded data and its Huffman tree from `deflate`
- handle converting decoded Huffman symbols back into LZ77 tokens in `inflate`
- document passing the tree to `inflate`
- add a small test showing compression followed by decompression

## Testing
- `node test/test.js`

------
https://chatgpt.com/codex/tasks/task_e_68409c412a2c83289660acb12b4f6d30