### PR TITLE
Add deflate/inflate test

### DIFF
--- a/libinflate.js
+++ b/libinflate.js
@@ -100,7 +100,7 @@ function deflate(data) {
     let huffmanTree = buildHuffmanTree(frequencies);
     let huffmanCodes = generateHuffmanCodes(huffmanTree);
     let encodedData = huffmanEncode(lz77Data, huffmanCodes);
-    return encodedData;
+    return { encodedData, huffmanTree };
 }
 
 function huffmanDecode(encodedData, huffmanTree) {
@@ -114,7 +114,13 @@ function huffmanDecode(encodedData, huffmanTree) {
         }
 
         if (node.symbol !== undefined) {
-            decoded.push(node.symbol);
+            let symbol = node.symbol;
+            if (/^\(\d+,\d+\)$/.test(symbol)) {
+                const [distance, length] = symbol.slice(1, -1).split(',').map(Number);
+                decoded.push({ distance, length });
+            } else {
+                decoded.push({ byte: symbol });
+            }
             node = huffmanTree;  // Reset to the root for the next symbol
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "libinflate",
+  "version": "1.0.0",
+  "main": "libinflate.js",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { deflate, inflate } = require('./libinflate');
+
+const input = 'The quick brown fox jumps over the lazy dog';
+
+const { encodedData, huffmanTree } = deflate(input);
+const outputArray = inflate(encodedData, huffmanTree);
+const output = outputArray.join('');
+
+assert.strictEqual(output, input);
+console.log('Test passed');


### PR DESCRIPTION
## Summary
- export Huffman tree from `deflate` so that data can be inflated
- parse Huffman symbols when decoding
- add `test.js` with an assertion-based round trip
- add `package.json` with test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409c43d27c8328a5026ac55157862f