### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,46 +5,10 @@ A simple implementation of the INFLATE (and DEFLATE) algorithm in JavaScript.
 ## Installation
 
 ```bash
-npm install libINFLATE```
-
-
-## Usage
-
-```javascript
-const { inflate, deflate } = require('libINFLATE');
-
-// Prepare an array of bytes/characters to compress
-const input = Array.from('example text');
-
-// deflate now returns the encoded data and the Huffman tree
-const { encodedData, huffmanTree } = deflate(input);
-
-// pass the tree back to `inflate` to get the original data
-const output = inflate(encodedData, huffmanTree).join('');
-=======
-# libINFLATE
-
-A simple implementation of the INFLATE (and DEFLATE) algorithm in JavaScript.
-
-## Installation
-
-```bash
 npm install libINFLATE
 ```
 
 ## Usage
-
-`deflate` compresses an array of bytes and returns an object containing the encoded bit string and the Huffman tree used during compression. `inflate` expects those two values in order to recreate the original data.
-
-```javascript
-const { deflate, inflate } = require('libINFLATE');
-
-const input = [/* array of byte values */];
-const { encodedData, huffmanTree } = deflate(input);
-const output = inflate(encodedData, huffmanTree);
-```
-
-### Example
 
 Below is a small example that compresses a string and then decompresses it back to verify the output.
 


### PR DESCRIPTION
## Summary
- remove duplicated README content
- retain a single example of installation and usage

## Testing
- `npm test`
- `node test/test.js` *(fails: parseSymbol is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff72715c8328938e19323714e5e7